### PR TITLE
026. remove duplicates from sorted array

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,10 @@ edition = "2021"
 rstest = "0.18.2"
 
 [[bin]]
+name = "go_project"
+path = "src/exam/go_project.rs"
+
+[[bin]]
 name = "two_sum"
 path = "src/001/two_sum.rs"
 
@@ -33,5 +37,5 @@ name = "mergew_two_sorted_lists"
 path = "src/021/mergew_two_sorted_lists.rs"
 
 [[bin]]
-name = "go_project"
-path = "src/exam/go_project.rs"
+name = "remove_duplicates_from_sorted_array"
+path = "src/026/remove_duplicates_from_sorted_array.rs"

--- a/rust/src/026/remove_duplicates_from_sorted_array.rs
+++ b/rust/src/026/remove_duplicates_from_sorted_array.rs
@@ -1,19 +1,29 @@
 /// @see https://leetcode.com/problems/remove-duplicates-from-sorted-array/
 ///
 /// @time_complexity O(N)
-/// @space_complexity O(N)
+/// @space_complexity O(1)
 ///
 impl Solution {
+    // Runtime 0ms, Memory 2.3MB
     pub fn remove_duplicates(nums: &mut Vec<i32>) -> i32 {
-        let mut len = nums.len();
-        while 1 < len {
-            let current = len - 1;
-            if nums[current] == nums[current - 1] {
-                nums.remove(current);
-            }
-            len -= 1;
-        }
+        nums.dedup();
         nums.len() as i32
+    }
+
+    // Runtime 2ms, Memory 2.1MB
+    pub fn remove_duplicates2(nums: &mut Vec<i32>) -> i32 {
+        if nums.is_empty() {
+            return 0;
+        }
+        let mut i = 0;
+        for j in 1..nums.len() {
+            if nums[j] != nums[i] {
+                i += 1;
+                nums[i] = nums[j];
+            }
+        }
+        nums.drain(i..nums.len() - 1);
+        (i + 1) as i32
     }
 }
 
@@ -24,8 +34,16 @@ use rstest::rstest;
 #[rstest]
 #[case(vec![1,1,2], 2, vec![1,2])]
 #[case(vec![0,0,1,1,1,2,2,3,3,4], 5, vec![0,1,2,3,4])]
-fn example_test(#[case] mut nums: Vec<i32>, #[case] expected: i32, #[case] nums2: Vec<i32>) {
+fn remove_duplicates_test(
+    #[case] mut nums: Vec<i32>,
+    #[case] expected: i32,
+    #[case] nums2: Vec<i32>,
+) {
     let actual = Solution::remove_duplicates(&mut nums);
+    assert_eq!(actual, expected);
+    assert_eq!(nums, nums2);
+
+    let actual = Solution::remove_duplicates2(&mut nums);
     assert_eq!(actual, expected);
     assert_eq!(nums, nums2);
 }

--- a/rust/src/026/remove_duplicates_from_sorted_array.rs
+++ b/rust/src/026/remove_duplicates_from_sorted_array.rs
@@ -1,0 +1,33 @@
+/// @see https://leetcode.com/problems/remove-duplicates-from-sorted-array/
+///
+/// @time_complexity O(N)
+/// @space_complexity O(N)
+///
+impl Solution {
+    pub fn remove_duplicates(nums: &mut Vec<i32>) -> i32 {
+        let mut len = nums.len();
+        while 1 < len {
+            let current = len - 1;
+            if nums[current] == nums[current - 1] {
+                nums.remove(current);
+            }
+            len -= 1;
+        }
+        nums.len() as i32
+    }
+}
+
+pub struct Solution;
+
+use rstest::rstest;
+
+#[rstest]
+#[case(vec![1,1,2], 2, vec![1,2])]
+#[case(vec![0,0,1,1,1,2,2,3,3,4], 5, vec![0,1,2,3,4])]
+fn example_test(#[case] mut nums: Vec<i32>, #[case] expected: i32, #[case] nums2: Vec<i32>) {
+    let actual = Solution::remove_duplicates(&mut nums);
+    assert_eq!(actual, expected);
+    assert_eq!(nums, nums2);
+}
+
+fn main() {}


### PR DESCRIPTION
## Summary

- **language** :  Rust  
- **problem** : https://leetcode.com/problems/remove-duplicates-from-sorted-array/submissions/

## Related Issues
https://github.com/sumiredc/leetcode/issues/2

## Details of the Changes

- rust/Cargo.toml

Added bin `remove_duplicates_from_sorted_array`.

## Testing
I passed two cases.

## Screenshots
None.

## Checklist
- [x] Solved the problem.
- [x] Tests pass successfully.

## Additional Comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced an enhanced method to remove duplicate entries from a list of numbers. This update improves the efficiency of data cleaning, ensuring only unique elements are retained.
- Improvement: Added a secondary method for duplicate removal, providing an alternative way to handle data redundancy.
- Test: Incorporated tests to validate the effectiveness and accuracy of the new duplicate removal methods. This ensures the reliability of these features in handling data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->